### PR TITLE
Don’t run some actions on forks (see #21)

### DIFF
--- a/.github/workflows/deployment-url.yml
+++ b/.github/workflows/deployment-url.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: 'Comment PR'
         uses: actions/github-script@0.3.0
+        # Don’t run the action on forks
+        if: github.repository == 'cesko-digital/movapp'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Tohle by mělo ve forcích zabránit spouštění GitHub Action, která komentuje PRs pomocí URL deploymentu ve Vercelu. Fixes #21.