### PR TITLE
Remove React imports and relative path imports

### DIFF
--- a/components/basecomponents/Button.tsx
+++ b/components/basecomponents/Button.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { forwardRef } from 'react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
 }
 
-export const Button = React.forwardRef((props: ButtonProps, ref: React.ForwardedRef<HTMLButtonElement>): JSX.Element => {
+export const Button = forwardRef((props: ButtonProps, ref: React.ForwardedRef<HTMLButtonElement>): JSX.Element => {
   const { text, className, ...rest } = props;
   return (
     <button className={`${className} bg-primary-blue text-white  h-auto rounded-lg py-2 px-5`} ref={ref} {...rest}>

--- a/components/basecomponents/Collapse.tsx
+++ b/components/basecomponents/Collapse.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement, useState } from 'react';
-import ChevronDown from '../../public/icons/chevron-down.svg';
-import ChevronRight from '../../public/icons/chevron-right.svg';
+import { ReactElement, useState } from 'react';
+import ChevronDown from 'public/icons/chevron-down.svg';
+import ChevronRight from 'public/icons/chevron-right.svg';
 
 interface CollapseProps {
   title: string | ReactElement;

--- a/components/basecomponents/Input.tsx
+++ b/components/basecomponents/Input.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import { HTMLProps } from 'react';
 
 export const SearchInput = (props: HTMLProps<HTMLInputElement>): JSX.Element => {
   const { className, ...rest } = props;

--- a/components/basecomponents/Modal.tsx
+++ b/components/basecomponents/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactNode } from 'react';
+import { Fragment, ReactNode } from 'react';
 import { Transition, Dialog } from '@headlessui/react';
 import { XIcon } from '@heroicons/react/outline';
 

--- a/components/basecomponents/ScrollToTop.tsx
+++ b/components/basecomponents/ScrollToTop.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import ChevronUp from '../../public/icons/chevron-up.svg';
+import ChevronUp from 'public/icons/chevron-up.svg';
 
 export const ScrollToTop = () => {
   const handleScrollTop = () => {

--- a/components/basecomponents/Translation.tsx
+++ b/components/basecomponents/Translation.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import PlayIcon from '../../public/icons/play.svg';
+import PlayIcon from 'public/icons/play.svg';
 import Marker from 'react-mark.js/Marker';
-import { Language } from '../../data/locales';
+import { Language } from 'data/locales';
 
 interface TranslationProps {
   translation: string;

--- a/components/basecomponents/TranslationsContainer.tsx
+++ b/components/basecomponents/TranslationsContainer.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { useTranslation } from 'next-i18next';
 import { Translation } from './Translation';
-import { Language } from '../../data/locales';
+import { Language } from 'data/locales';
 
 export interface Translation {
   cz_translation: string;

--- a/components/sections/CategoryDictionary.tsx
+++ b/components/sections/CategoryDictionary.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Translation, TranslationContainer } from '../basecomponents/TranslationsContainer';
+import { Translation, TranslationContainer } from 'components/basecomponents/TranslationsContainer';
 
 interface CategoryDictionaryProps {
   translations: Translation[];

--- a/components/sections/ExportTranslations.tsx
+++ b/components/sections/ExportTranslations.tsx
@@ -1,9 +1,9 @@
-import React, { DetailedHTMLProps, Fragment, InputHTMLAttributes, LabelHTMLAttributes, ReactNode, useState } from 'react';
-import { Button } from '../basecomponents/Button';
-import { Modal } from '../basecomponents/Modal';
+import { DetailedHTMLProps, Fragment, InputHTMLAttributes, LabelHTMLAttributes, ReactNode, useState } from 'react';
+import { Button } from 'components/basecomponents/Button';
+import { Modal } from 'components/basecomponents/Modal';
 import { useTranslation } from 'next-i18next';
-import { Translation } from '../basecomponents/TranslationsContainer';
-import { Language } from '../../data/locales';
+import { Translation } from 'components/basecomponents/TranslationsContainer';
+import { Language } from 'data/locales';
 
 const PREVIEW_PHRASES_COUNT = 3;
 const CUSTOM_SEPARATOR_MAX_LENGTH = 30;
@@ -112,7 +112,7 @@ const ExportTranslations = ({ translations, categoryName, trigger }: ExportTrans
           <div>
             <H3>{t('export_translations.between_phrase_and_translation')}:</H3>
             {TRANSLATION_SEPARATORS.map((option, index) => (
-              <React.Fragment key={index}>
+              <Fragment key={index}>
                 <RadioButton
                   id={option.id}
                   name={'translationSeparator'}
@@ -124,7 +124,7 @@ const ExportTranslations = ({ translations, categoryName, trigger }: ExportTrans
                   {t(option.nameKey)} {option.displayValue ?? `(${option.value})`}
                 </Label>
                 <br />
-              </React.Fragment>
+              </Fragment>
             ))}
             <RadioButton
               id={TRANS_SEP_CUSTOM}
@@ -146,7 +146,7 @@ const ExportTranslations = ({ translations, categoryName, trigger }: ExportTrans
           <div>
             <H3>{t('export_translations.between_phrases')}:</H3>
             {PHRASE_SEPARATORS.map((option, index) => (
-              <React.Fragment key={index}>
+              <Fragment key={index}>
                 <RadioButton
                   id={option.id}
                   name={'phraseSeparator'}
@@ -158,7 +158,7 @@ const ExportTranslations = ({ translations, categoryName, trigger }: ExportTrans
                   {t(option.nameKey)} {option.displayValue ?? `(${option.value})`}
                 </Label>
                 <br />
-              </React.Fragment>
+              </Fragment>
             ))}
             <RadioButton
               id={PHRASE_SEP_CUSTOM}

--- a/components/sections/Layout/Footer.tsx
+++ b/components/sections/Layout/Footer.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'next-i18next';
 import Link from 'next/link';
-import React from 'react';
-import { FOOTER_NAVIGATION } from '../../../data/footerNavigation';
+import { FOOTER_NAVIGATION } from 'data/footerNavigation';
 
 export const Footer = () => {
   const { t } = useTranslation();

--- a/components/sections/Layout/Header/Header.tsx
+++ b/components/sections/Layout/Header/Header.tsx
@@ -2,10 +2,9 @@ import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React from 'react';
-import { HEADER_NAVIGATION } from '../../../../data/headerNavigation';
-import { LOCALES } from '../../../../data/locales';
-import AppLogo from '../../../../public/movapp-logo.png';
+import { HEADER_NAVIGATION } from 'data/headerNavigation';
+import { LOCALES } from 'data/locales';
+import AppLogo from 'public/movapp-logo.png';
 
 export const Header = () => {
   const { t, i18n } = useTranslation('common');

--- a/components/sections/Layout/Header/MobileHeader.tsx
+++ b/components/sections/Layout/Header/MobileHeader.tsx
@@ -2,12 +2,12 @@ import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
-import { HEADER_NAVIGATION } from '../../../../data/headerNavigation';
-import { LOCALES } from '../../../../data/locales';
-import BurgerIcon from '../../../../public/icons/burger.svg';
-import CloseIcon from '../../../../public/icons/close.svg';
-import AppLogo from '../../../../public/movapp-logo.png';
+import { useEffect, useState } from 'react';
+import { HEADER_NAVIGATION } from 'data/headerNavigation';
+import { LOCALES } from 'data/locales';
+import BurgerIcon from 'public/icons/burger.svg';
+import CloseIcon from 'public/icons/close.svg';
+import AppLogo from 'public/movapp-logo.png';
 
 export const MobileHeader = () => {
   const [showNavigation, setShowNavigation] = useState(false);

--- a/components/sections/Layout/Header/index.tsx
+++ b/components/sections/Layout/Header/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Header } from './Header';
 import { MobileHeader } from './MobileHeader';
 

--- a/components/sections/Layout/Layout.tsx
+++ b/components/sections/Layout/Layout.tsx
@@ -1,7 +1,7 @@
 import Script from 'next/script';
 import { Footer } from './Footer';
 import Header from './Header/index';
-import { ScrollToTop } from '../../basecomponents/ScrollToTop';
+import { ScrollToTop } from 'components/basecomponents/ScrollToTop';
 
 interface LayoutProps {
   children: React.ReactNode;

--- a/data/translations/translations.ts
+++ b/data/translations/translations.ts
@@ -1,4 +1,4 @@
-import { Translation } from '../../components/basecomponents/TranslationsContainer';
+import { Translation } from 'components/basecomponents/TranslationsContainer';
 // JSON translation files
 import Basic from './basic.json';
 import UzitecneFraze from './uzitecne-fraze.json';

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
   },
   "jest": {
     "preset": "ts-jest",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleDirectories": [
+      "node_modules",
+      "."
+    ]
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
-import '../styles/globals.css';
+import 'styles/globals.css';
 import type { AppProps } from 'next/app';
-import { Layout } from '../components/sections/Layout/Layout';
+import { Layout } from 'components/sections/Layout/Layout';
 import { appWithTranslation } from 'next-i18next';
 
 import '@fontsource/roboto/900.css';

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/jsx-key*/
 import { useTranslation, Trans } from 'next-i18next';
-import React from 'react';
-export { getStaticProps } from '../../utils/localization';
+export { getStaticProps } from 'utils/localization';
 import Link from 'next/link';
 import Head from 'next/head';
 

--- a/pages/contacts/index.tsx
+++ b/pages/contacts/index.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable react/jsx-key*/
 import { Trans, useTranslation } from 'next-i18next';
 import Head from 'next/head';
-import React from 'react';
-import { LinkText } from '../about';
-export { getStaticProps } from '../../utils/localization';
+import { LinkText } from 'pages/about';
+export { getStaticProps } from 'utils/localization';
 
 const Contacts = () => {
   const { t } = useTranslation();

--- a/pages/dictionary/index.tsx
+++ b/pages/dictionary/index.tsx
@@ -1,16 +1,16 @@
 import { useTranslation } from 'next-i18next';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
-import React, { useState } from 'react';
-import { Button } from '../../components/basecomponents/Button';
-import { Collapse } from '../../components/basecomponents/Collapse';
-import { SearchInput } from '../../components/basecomponents/Input';
-import { CategoryDictionary } from '../../components/sections/CategoryDictionary';
-import { translations, TranslationsType } from '../../data/translations/translations';
-export { getStaticProps } from '../../utils/localization';
+import { useState } from 'react';
+import { Button } from 'components/basecomponents/Button';
+import { Collapse } from 'components/basecomponents/Collapse';
+import { SearchInput } from 'components/basecomponents/Input';
+import { CategoryDictionary } from 'components/sections/CategoryDictionary';
+import { translations, TranslationsType } from 'data/translations/translations';
+export { getStaticProps } from 'utils/localization';
 import Marker from 'react-mark.js/Marker';
 // Disable ssr for this component to avoid Reference Error: Blob is not defined
-const ExportTranslations = dynamic(() => import('../../components/sections/ExportTranslations'), {
+const ExportTranslations = dynamic(() => import('components/sections/ExportTranslations'), {
   ssr: false,
 });
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,12 @@
 import { useTranslation } from 'next-i18next';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-export { getStaticProps } from '../utils/localization';
+export { getStaticProps } from 'utils/localization';
 import Link from 'next/link';
 import Image from 'next/image';
-import HeartsUkraine from '../public/hearts-for-ukraine.png';
-import DictionaryIcon from '../public/icons/book-font.svg';
-import MovappIcon from '../public/icons/movapp-bw-icon.svg';
+import HeartsUkraine from 'public/hearts-for-ukraine.png';
+import DictionaryIcon from 'public/icons/book-font.svg';
+import MovappIcon from 'public/icons/movapp-bw-icon.svg';
 
 const Home: NextPage = () => {
   const { t } = useTranslation();

--- a/tests/translations.test.ts
+++ b/tests/translations.test.ts
@@ -1,23 +1,23 @@
 /*
-  Do not forget to import all *.json files ../data/translations and included them into sections array.
+  Do not forget to import all *.json files data/translations and included them into sections array.
   I have no idea how to do it automatically. Let's do it manually.
  */
 
-import Basic from '../data/translations/basic.json';
-import UzitecneFraze from '../data/translations/uzitecne-fraze.json';
-import Cas from '../data/translations/cas.json';
-import HromadnaDoprava from '../data/translations/hromadna-doprava.json';
-import Zoo from '../data/translations/zoo.json';
-import NaNakupu from '../data/translations/na-nakupu.json';
-import NaUrade from '../data/translations/na-urade.json';
-import ObleceniDrogerie from '../data/translations/obleceni-drogerie.json';
-import Penize from '../data/translations/penize.json';
-import Rodina from '../data/translations/rodina.json';
-import Doctor from '../data/translations/doctor.json';
-import VDomacnosti from '../data/translations/vdomacnosti.json';
-import VeMeste from '../data/translations/vemeste.json';
-import VeSkole from '../data/translations/veskole.json';
-import VeSkolce from '../data/translations/veskolce.json';
+import Basic from 'data/translations/basic.json';
+import UzitecneFraze from 'data/translations/uzitecne-fraze.json';
+import Cas from 'data/translations/cas.json';
+import HromadnaDoprava from 'data/translations/hromadna-doprava.json';
+import Zoo from 'data/translations/zoo.json';
+import NaNakupu from 'data/translations/na-nakupu.json';
+import NaUrade from 'data/translations/na-urade.json';
+import ObleceniDrogerie from 'data/translations/obleceni-drogerie.json';
+import Penize from 'data/translations/penize.json';
+import Rodina from 'data/translations/rodina.json';
+import Doctor from 'data/translations/doctor.json';
+import VDomacnosti from 'data/translations/vdomacnosti.json';
+import VeMeste from 'data/translations/vemeste.json';
+import VeSkole from 'data/translations/veskole.json';
+import VeSkolce from 'data/translations/veskolce.json';
 
 const sections = [
   Basic,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": "."
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Dvě drobnosti:

* Ty složitější relativní importy typu `../../../foo` se blbě čtou. V `tsconfig.json` jde nastavit `baseUrl: "."`, díky čemuž pak jde psát všechny importy relativně ke kořenu repa, což je mnohem čitelnější.
* Od Reactu 17 není nutné v JSX souborech explicitně importovat samotný React ([viz tady](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)), ušetří se tím jeden import.