### PR TITLE
Add two redirects for moved image and pdf files

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -36,6 +36,16 @@ const nextConfig = {
         destination: '/uk/:path*',
         permanent: true,
       },
+      {
+        source: '/movapp-cover.jpg',
+        destination: '/icons/movapp-cover.jpg',
+        permanent: true,
+      },
+      {
+        source: '/omalovanky.pdf',
+        destination: '/kids/omalovanky.pdf',
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
Redirecting:
/movapp-cover.jpg => /icons/movapp-cover.jpg
/omalovanky.pdf => /kids/omalovanky.pdf

to fix broken links from:
https://github.com/cesko-digital/movapp/pull/56