### PR TITLE
Fix resetting search: remove non-sensical condition, define props explicitly

### DIFF
--- a/components/basecomponents/SearchInput.tsx
+++ b/components/basecomponents/SearchInput.tsx
@@ -1,12 +1,18 @@
-import { forwardRef, HTMLProps } from 'react';
+import { forwardRef } from 'react';
 
-interface SearchInputProps extends HTMLProps<HTMLInputElement> {
+interface SearchInputProps {
+  id: string;
+  label: string;
+  value: string;
+  placeholder: string;
   hiddenLabel: boolean;
+  setSearch: (value: string) => void;
   resetInput?: () => void;
+  className?: string;
 }
 
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
-  ({ hiddenLabel, id, label, resetInput, value, type, className, ...rest }, ref): JSX.Element => {
+  ({ hiddenLabel, id, label, resetInput, value, className, placeholder, setSearch }, ref): JSX.Element => {
     return (
       <div className={`relative ${className} transition duration-500 w-full`}>
         {label && (
@@ -16,13 +22,13 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
         )}
         <input
           ref={ref}
-          {...rest}
           value={value}
-          type={type}
           id={id}
-          className={` rounded-md md:rounded-lg  focus:border-yellow-400 box-border w-full h-[44px] focus:border-2 py-2 px-3 text-dark-700 border-1 border-primary-blue outline-none shadow-s`}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={placeholder}
+          className={`rounded-md md:rounded-lg  focus:border-yellow-400 box-border w-full h-[44px] focus:border-2 py-2 px-3 text-dark-700 border-1 border-primary-blue outline-none shadow-s`}
         />
-        {type === 'text' && value?.toString().trim() && (
+        {value?.trim() && (
           <button
             onClick={resetInput}
             type="reset"

--- a/pages/dictionary/index.tsx
+++ b/pages/dictionary/index.tsx
@@ -3,7 +3,6 @@ import dynamic from 'next/dynamic';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from 'components/basecomponents/Button';
 import { Collapse } from 'components/basecomponents/Collapse';
-import { SearchInput } from 'components/basecomponents/Input';
 import { CategoryDictionary } from 'components/sections/CategoryDictionary';
 import { categories, Category } from 'data/translations/translations';
 export { getStaticProps } from 'utils/localization';
@@ -14,6 +13,7 @@ import { normalizeForId, normalize } from 'utils/textNormalizationUtils';
 import { DictionarySearchResults } from 'components/sections/DictionarySearchResults';
 import { Language } from 'data/locales';
 import SEO from 'components/basecomponents/SEO';
+import { SearchInput } from 'components/basecomponents/SearchInput';
 // Disable ssr for this component to avoid Reference Error: Blob is not defined
 const ExportTranslations = dynamic(() => import('../../components/sections/ExportTranslations'), {
   ssr: false,
@@ -107,7 +107,7 @@ const Dictionary = () => {
             placeholder={t('dictionary_page.search_placeholder')}
             value={search}
             resetInput={() => setSearch('')}
-            onChange={(e: React.FormEvent<HTMLInputElement>) => setSearch((e.target as HTMLInputElement).value)}
+            setSearch={setSearch}
           />
           <Button
             ref={searchButton}


### PR DESCRIPTION
* The rest icon was not being displayed due to unnecesary `type === 'text'` condition. I removed the condition.
* The type prop was previously removed because SearchInput will only ever be of type text and that is the default value. The error was not obvious because of the way props were typed. I think extending default HTML props should only be done for very simple wrapper components were you don't use the props for anything else other than passing them on. This component does a lot of stuff so it's better to define all props explicitly, otherwise you risk wrongly assuming a prop is provided when it isn't, like we did in this case. I redefined the props interface to spell out all necessary props explicitly.