### PR TITLE
add plausible tracking using a library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "marked": "^4.0.12",
         "next": "12.1.0",
         "next-i18next": "^10.5.0",
+        "next-plausible": "^3.6.2",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-icons": "^4.3.1",
@@ -8530,6 +8531,19 @@
       "peerDependencies": {
         "next": ">= 10.0.0",
         "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/next-plausible": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.6.2.tgz",
+      "integrity": "sha512-WhyFo0ZjoActGHFtkBiTxgZ0ALLkrKEqpgH/G2JXFqfg2Dx6/ne2fjKvXDGyyL4IYIXnWz/UFJFq40TxbGa5zA==",
+      "funding": {
+        "url": "https://github.com/4lejandrito/next-plausible?sponsor=1"
+      },
+      "peerDependencies": {
+        "next": "^11.1.0 || ^12.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/next-sitemap": {
@@ -17310,6 +17324,12 @@
         "i18next-fs-backend": "^1.0.7",
         "react-i18next": "^11.15.5"
       }
+    },
+    "next-plausible": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.6.2.tgz",
+      "integrity": "sha512-WhyFo0ZjoActGHFtkBiTxgZ0ALLkrKEqpgH/G2JXFqfg2Dx6/ne2fjKvXDGyyL4IYIXnWz/UFJFq40TxbGa5zA==",
+      "requires": {}
     },
     "next-sitemap": {
       "version": "3.1.7",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "marked": "^4.0.12",
     "next": "12.1.0",
     "next-i18next": "^10.5.0",
+    "next-plausible": "^3.6.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-icons": "^4.3.1",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,9 +1,16 @@
 export { getStaticProps } from '../utils/localization';
 import { useTranslation } from 'next-i18next';
+import { usePlausible } from 'next-plausible';
 import NextErrorComponent from 'next/error';
+import { useEffect } from 'react';
 
 const Custom404 = () => {
   const { t } = useTranslation();
+  const plausible = usePlausible();
+  useEffect(() => {
+    plausible('404', { props: { path: document.location.pathname } });
+  }, [plausible]);
+
   return <NextErrorComponent statusCode={404} title={t('errors.pageNotFound')} />;
 };
 


### PR DESCRIPTION
Added the plausible tracking of 404 pages. This solution uses a quite popular and updated library. We might consider using this library also for initializing plausible.

It'd possible to implement this also without using a library, in  case someone doesn't like this approach.

There needs to be action in plausible as well, in order to track it. Someone with access there needs to set this up: https://plausible.io/docs/error-pages-tracking-404#3-create-a-custom-event-goal-in-your-plausible-analytics-account