### PR TITLE
Some cleanup

### DIFF
--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -1,4 +1,5 @@
 /// <reference types="Cypress" />
+import { checkLink, checkVisibility } from '../support/cypressHelpers';
 
 describe('Test Movapp - Home page', () => {
   beforeEach(() => {
@@ -6,43 +7,35 @@ describe('Test Movapp - Home page', () => {
   });
 
   it('Test that page has correct h1', () => {
-    cy.get('h1').should('contain.text', 'Naučte se základy češtiny a ukrajinštiny pro běžné životní situace');
-    cy.get('h1').invoke('text').should('not.be.empty') 
+    cy.get('h1').as('heading');
+    cy.get('@heading').should('contain.text', 'Naučte se základy češtiny a ukrajinštiny pro běžné životní situace');
+    cy.get('@heading').invoke('text').should('not.be.empty');
   });
 
   it('Test that page has a correct title', () => {
-    cy.title().should("be.eq", "Movapp.cz – aby se Češi a Ukrajinci snadno domluvili");
+    cy.title().should('be.eq', 'Movapp.cz – aby se Češi a Ukrajinci snadno domluvili');
   });
 
-   it('Test that Nav bar has a correct sections', () => {
-    cy.contains('header a', 'Abeceda').invoke('attr', 'href').should('equal', '/alphabet')
-    cy.contains('header a', 'Slovníček').invoke('attr', 'href').should('equal', '/dictionary')
+  it('Test that Nav bar has a correct sections', () => {
+    checkLink('Abeceda', '/alphabet');
+    checkLink('Slovníček', '/dictionary');
+    checkLink('Wiki', '/wiki');
+    checkLink('O nás', '/about');
+    checkLink('Kontakty', '/contacts');
+
     cy.contains('header button', 'Pro děti').invoke('text').should('equal', 'Pro děti');
-    cy.contains('header a', 'Wiki').invoke('attr', 'href').should('equal', '/wiki');
-    cy.contains('header a', 'O nás').invoke('attr', 'href').should('equal', '/about');
-    cy.contains('header a', 'Kontakty').invoke('attr', 'href').should('equal', '/contacts');
   });
 
-  it('Test visibility of the elements in Header', () => {
-    cy.contains('header a', 'Abeceda').should('be.visible');
-    cy.contains('header a', 'Slovníček').should('be.visible');
-    cy.contains('header button', 'Pro děti').should('be.visible');
-    cy.contains('header a', 'Wiki').should('be.visible');
-    cy.contains('header a', 'O nás').should('be.visible');
-    cy.contains('header a', 'Kontakty').should('be.visible');
+  it('Test body part of the page', () => {
+    checkVisibility('h2', 'Pro děti');
+    checkVisibility('h2', 'Wiki');
+    checkVisibility('h2', 'Movapp je');
+    checkVisibility('h2', 'Ukrajinská abeceda');
   });
 
-it('Test body part of the page', () => {
-    cy.contains('h2', 'Pro děti').should('be.visible');
-    cy.contains('h2', 'Wiki').should('be.visible');
-    cy.contains('h2', 'Movapp je').should('be.visible');
-    cy.contains('h2', 'Ukrajinská abeceda').should('be.visible');
-  });
-
-it('Test of footer of the page', () => {
+  it('Test of footer of the page', () => {
     cy.contains('Movapp mluví dalšími jazyky').should('be.visible');
     cy.contains('Slovensky').should('be.visible');
-    cy.contains('Polski').should('be.visible')
-    
+    cy.contains('Polski').should('be.visible');
   });
-})
+});

--- a/cypress/support/cypressHelpers.ts
+++ b/cypress/support/cypressHelpers.ts
@@ -1,0 +1,12 @@
+/// <reference types="Cypress" />
+export const checkLink = (text: string, href: string) => {
+  cy.contains('header a', text)
+    .should('be.visible')
+    .and(($a) => {
+      expect($a.attr('href')).to.eq(href);
+    });
+};
+
+export const checkVisibility = (tag: string, text: string) => {
+  cy.contains(tag, text).should('be.visible');
+};


### PR DESCRIPTION
- use alias to have less DOM traversals (@heading)
- creates helper functions for better maintanance and more concise (checkLink, checkVisibility)
- check link chain visibility and href attribute, so we do not need two separate tests