### PR TITLE
Introducing contributing.md file to be sure we are on same page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 - Make sure that you are using the latest version.
 - Determine if your bug is really a bug and not an error on your side. If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/cesko-digital/movappissues?q=label%3Abug).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://trello.com/b/XumGa4K8/movapp-backlog?filter=label:CHYBA).
 - Collect information about the bug:
     - Console log
     - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
@@ -45,7 +45,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](https://github.com/cesko-digital/movapp/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Open an [Issue](https://trello.com/b/XumGa4K8/movapp-backlog). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own.
 - Provide the information you collected in the previous section.
@@ -60,12 +60,12 @@ This section guides you through submitting an enhancement suggestion for Movapp,
 
 #### Before Submitting an Enhancement
 
-- Perform a [search](https://github.com/cesko-digital/movapp/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Perform a [search](https://trello.com/b/XumGa4K8/movapp-backlog) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/cesko-digital/movapp/issues).
+Enhancement suggestions are tracked as [Trello](https://trello.com/b/XumGa4K8/movapp-backlog).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to Movapp
+
+First off, thanks for taking the time to contribute! ❤️
+
+All types of contributions are encouraged and valued. See the [Table of Contents](#table-of-contents) for different ways to help and details about how this project handles them. Please make sure to read the relevant section before making your contribution. It will make it a lot easier for us maintainers and smooth out the experience for all involved. The community looks forward to your contributions. 🎉
+
+> And if you like the project, but just don't have time to contribute, that's fine. There are other easy ways to support the project and show your appreciation, which we would also be very happy about:
+> - Tweet about it
+> - Follow us on social media
+> - Mention the project at local meetups and tell your friends/colleagues
+
+## Table of Contents
+
+- [I Want To Contribute](#i-want-to-contribute)
+    - [Reporting Bugs](#reporting-bugs)
+    - [Suggesting Enhancements](#suggesting-enhancements)
+    - [Your First Code Contribution](#your-first-code-contribution)
+- [Styleguides](#styleguides)
+    - [Commit Messages](#commit-messages)
+- [Join The Project Team](#join-the-project-team)
+
+## I Want To Contribute
+
+> ### Legal Notice
+> When contributing to this project, you must agree that you have authored 100% of the content, that you have the necessary rights to the content and that the content you contribute may be provided under the project license.
+
+### Reporting Bugs
+
+#### Before Submitting a Bug Report
+
+A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
+
+- Make sure that you are using the latest version.
+- Determine if your bug is really a bug and not an error on your side. If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/cesko-digital/movappissues?q=label%3Abug).
+- Collect information about the bug:
+    - Console log
+    - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)
+    - Possibly your input and the output
+    - Can you reliably reproduce the issue? And can you also reproduce it with older versions?
+
+#### How Do I Submit a Good Bug Report?
+
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to.
+
+We use GitHub issues to track bugs and errors. If you run into an issue with the project:
+
+- Open an [Issue](https://github.com/cesko-digital/movapp/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Explain the behavior you would expect and the actual behavior.
+- Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own.
+- Provide the information you collected in the previous section.
+
+Once it's filed:
+
+- A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps.
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for Movapp, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+
+#### Before Submitting an Enhancement
+
+- Perform a [search](https://github.com/cesko-digital/movapp/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
+
+#### How Do I Submit a Good Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/cesko-digital/movapp/issues).
+
+- Use a **clear and descriptive title** for the issue to identify the suggestion.
+- Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
+- **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
+- You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+- **Explain why this enhancement would be useful** to most Movapp users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+
+### Your First Code Contribution
+
+- Make sure you have permission to write to the repository
+- Create a new branch based on `main` branch with name convention `<ID of issue>-short-description`
+- Make your changes.
+- Submit a pull request with well described description of why you did those changes.
+- Wait for PR GitHub actions finishes.
+- Wait for code review from a team member.
+- Every conversation must be resolved by reviewer.
+- Before merging make sure that the branch is rebased on `main`.
+- Before merging make sure that there are no conflicts. In case you have a conflicts on the code you must resolve it.
+- Once you have approved PR you can merge the PR with `Squash and merge` policy.
+
+## Styleguides
+### Commit Messages
+Every commit message must describe purpose of the change and refers to issue if possible e.g. `#30 Added new team member to list of members`.
+
+<!-- ### Code style -->
+<!-- TODO: fill in set of rules or reference to linter/prettier configuration -->
+
+## Join The Project Team
+ If you wish to help us with further development of the project, please fill out the form at [cesko.digital/join](https://cesko.digital/join) and join our Slack channel `#ua-movaapp`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Movapp
+# Contributing to Movapp [Proposal]
 
 First off, thanks for taking the time to contribute! ❤️
 


### PR DESCRIPTION
@met Asked me to create contributing style guides.

There is a proposal. I suggest having it only in this repository and reffer to it from our other repositories and creating only exceptions for the specific repository.

The main part is generated by https://generator.contributing.md/# and reviewed by me. This is mainly used by open source libraries/tools so I had to change it a little bit for our purpose.