### PR TITLE
add redirect from /newsletter to the external page for cs locale

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -54,6 +54,13 @@ const nextConfig = {
         destination: '/dictionary#casopis_raketa_detem',
         permanent: true,
       },
+      {
+        source: '/cs/newsletter',
+        destination: 'https://airtable.com/appLciQqZNGDR3J6W/shrImIIFcXtg4JYLE',
+        locale: false,
+        basePath: false,
+        permanent: false,
+      }
     ];
   },
 };


### PR DESCRIPTION
## Steps to Reproduce
1. Visit the `/newsletter` path.

## Expected Behavior
If the locale is `cs`, the user will be redirected to the external page (https://airtable.com/appLciQqZNGDR3J6W/shrImIIFcXtg4JYLE).